### PR TITLE
fix: multiple PHP 8.1 compatibility and functional issues in Tokenizer

### DIFF
--- a/SmartyLint/Cli.php
+++ b/SmartyLint/Cli.php
@@ -58,7 +58,7 @@ class SmartyLint_Cli {
      * @return array
      */
     public function getCommandLineValues() {
-        if (empty($this->values) === false) {
+        if (! empty($this->values)) {
             return $this->values;
         }
 
@@ -70,14 +70,14 @@ class SmartyLint_Cli {
                 continue;
             }
 
-            if ($arg{0} === '-') {
+            if ($arg[0] === '-') {
                 if ($arg === '-' || $arg === '--') {
                     // Empty argument, ignore it.
                     continue;
                 }
 
 
-                if ($arg{1} === '-') {
+                if ($arg[1] === '-') {
                     $values
                         = $this->processLongArgument(substr($arg, 2), $i, $values);
                 } else {
@@ -154,17 +154,17 @@ class SmartyLint_Cli {
                 exit(0);
                 break;
             default:
-                if (substr($arg, 0, 11) === 'extensions=') {
+                if (str_starts_with($arg, 'extensions=')) {
                     $values['extensions'] = explode(',', substr($arg, 11));
-                } else if (substr($arg, 0, 6) === 'files=') {
+                } else if (str_starts_with($arg, 'files=')) {
                     $values['files'] = explode(',', substr($arg, 6));
-                } else if (substr($arg, 0, 15) === 'left-delimiter=') {
+                } else if (str_starts_with($arg, 'left-delimiter=')) {
                     $values['leftDelimiter'] = substr($arg, 15);
-                } else if (substr($arg, 0, 16) === 'right-delimiter=') {
+                } else if (str_starts_with($arg, 'right-delimiter=')) {
                     $values['rightDelimiter'] = substr($arg, 16);
-                } else if (substr($arg, 0, 6) === 'rules=') {
+                } else if (str_starts_with($arg, 'rules=')) {
                     $values['rules'] = substr($arg, 6);
-                } else if (substr($arg, 0, 13) === 'auto-literal=') {
+                } else if (str_starts_with($arg, 'auto-literal=')) {
                     $values['autoLiteral'] = substr($arg, 13);
                 }
                 break;
@@ -186,14 +186,14 @@ class SmartyLint_Cli {
      */
     public function processUnknownArgument($arg, $pos, $values) {
         // We don't know about any additional switches; just files.
-        if ($arg{0} === '-') {
+        if ($arg[0] === '-') {
             echo 'ERROR: option "'.$arg.'" not known.'.PHP_EOL.PHP_EOL;
             $this->printUsage();
             exit(2);
         }
 
         $file = realpath($arg);
-        if (file_exists($file) === false) {
+        if (! file_exists($file)) {
             echo 'ERROR: The file "'.$arg.'" does not exist.'.PHP_EOL.PHP_EOL;
             $this->printUsage();
             exit(2);
@@ -212,26 +212,26 @@ class SmartyLint_Cli {
      * @see getCommandLineValues()
      */
     public function process($values=array()) {
-        if (empty($values) === true) {
+        if (empty($values)) {
             $values = $this->getCommandLineValues();
         }
         $lint = new SmartyLint();
 
         // Set file extensions if they were specified. Otherwise,
         // let SmartyLint decide on the defaults.
-        if (empty($values['extensions']) === false) {
+        if (! empty($values['extensions'])) {
             $lint->setAllowedFileExtensions($values['extensions']);
         }
 
-        if (empty($values['leftDelimiter']) === false) {
+        if (! empty($values['leftDelimiter'])) {
             $lint->setLeftDelimiter($values['leftDelimiter']);
         }
 
-        if (empty($values['rightDelimiter']) === false) {
+        if (! empty($values['rightDelimiter'])) {
             $lint->setRightDelimiter($values['rightDelimiter']);
         }
 
-        if (empty($values['autoLiteral']) === false) {
+        if (! empty($values['autoLiteral'])) {
             $lint->setAutoLiteral($values['autoLiteral']);
         }
 

--- a/SmartyLint/CommentParser/AbstractDocElement.php
+++ b/SmartyLint/CommentParser/AbstractDocElement.php
@@ -110,9 +110,7 @@ abstract class SmartyLint_CommentParser_AbstractDocElement implements SmartyLint
         $tag,
         SmartyLint_File $smartylFile
     ) {
-        if ($previousElement !== null
-            && ($previousElement instanceof SmartyLint_CommentParser_DocElement) === false
-        ) {
+        if (! ($previousElement instanceof SmartyLint_CommentParser_DocElement)) {
             $error = '$previousElement must be an instance of DocElement';
             throw new Exception($error);
         }
@@ -129,7 +127,7 @@ abstract class SmartyLint_CommentParser_AbstractDocElement implements SmartyLint
 
         $subElements = $this->getSubElements();
 
-        if (is_array($subElements) === false) {
+        if (! is_array($subElements)) {
             throw new Exception('getSubElements() must return an array');
         }
 

--- a/SmartyLint/CommentParser/CommentElement.php
+++ b/SmartyLint/CommentParser/CommentElement.php
@@ -81,11 +81,11 @@ class SmartyLint_CommentParser_CommentElement extends SmartyLint_CommentParser_S
         foreach ($this->tokens as $pos => $token) {
             $token = str_replace($whiteSpace, '', $token);
             if ($token === $this->smartylFile->eolChar) {
-                if ($found === false) {
+                if (! $found) {
                     // Include newlines before short description.
                     continue;
                 } else {
-                    if (isset($this->tokens[($pos + 1)]) === true) {
+                    if (isset($this->tokens[($pos + 1)])) {
                         if ($this->tokens[($pos + 1)] === $this->smartylFile->eolChar) {
                             return ($pos - 1);
                         }
@@ -134,7 +134,7 @@ class SmartyLint_CommentParser_CommentElement extends SmartyLint_CommentParser_S
         for ($i = $pos; $i < $count; $i++) {
             $content = trim($this->tokens[$i]);
             if ($content !== '') {
-                if ($content{0} === '@') {
+                if ($content[0] === '@') {
                     return -1;
                 }
 

--- a/SmartyLint/CommentParser/FileCommentParser.php
+++ b/SmartyLint/CommentParser/FileCommentParser.php
@@ -113,6 +113,13 @@ class SmartyLint_CommentParser_FileCommentParser {
     public $orders = array();
 
     /**
+     * The element that represents this comment element.
+     *
+     * @var DocElement
+     */
+    protected $comment = null;
+
+    /**
      * Constructs a SmartyLint_CommentParser_FileCommentParser.
      *
      * @param string          $comment     The comment to parse.
@@ -132,7 +139,7 @@ class SmartyLint_CommentParser_FileCommentParser {
      *                                                       comment.
      */
     public function parse() {
-        if ($this->_hasParsed === false) {
+        if (! $this->_hasParsed) {
             $this->_parse($this->commentString);
         }
     }
@@ -158,7 +165,7 @@ class SmartyLint_CommentParser_FileCommentParser {
                     $line = substr($line, $lEnd);
                 } else if (substr($line, -($rEnd), $rEnd) === ('*'.$this->smartylFile->rDelimiter)) {
                     $line = substr($line, 0, -($rEnd));
-                } else if ($line{0} === '*') {
+                } else if ($line[0] === '*') {
                     $line = substr($line, 1);
                 }
 
@@ -197,18 +204,16 @@ class SmartyLint_CommentParser_FileCommentParser {
             if (trim($word) !== '') {
                 $wordWasEmpty = false;
             }
-            if ($word{0} === '@') {
+            if ($word[0] === '@') {
                 $tag = substr($word, 1);
 
                 // Filter out @ tags in the comment description.
                 // A real comment tag should have whitespace and a newline before it.
-                if (isset($this->words[($wordPos - 1)]) === false
-                    || trim($this->words[($wordPos - 1)]) !== ''
-                ) {
+                if (!empty($this->words[$wordPos - 1])) {
                     continue;
                 }
 
-                if (isset($this->words[($wordPos - 2)]) === false
+                if (! isset($this->words[($wordPos - 2)])
                     || $this->words[($wordPos - 2)] !== $this->smartylFile->eolChar
                 ) {
                     continue;
@@ -232,7 +237,7 @@ class SmartyLint_CommentParser_FileCommentParser {
 
                 $prevTagPos = $wordPos;
 
-                if (in_array($tag, $allowedTagNames) === false) {
+                if (! in_array($tag, $allowedTagNames)) {
                     // This is not a tag that we process, but let's check to
                     // see if it is a tag we know about. If we don't know about it,
                     // we add it to a list of unknown tags.
@@ -244,7 +249,7 @@ class SmartyLint_CommentParser_FileCommentParser {
                             'tutorial',
                             'package_version@',
                         );
-                    if (in_array($tag, $knownTags) === false) {
+                    if (! in_array($tag, $knownTags)) {
                         $this->unknown[] = array(
                                 'tag'  => $tag,
                                 'line' => $this->getLine($wordPos),
@@ -256,7 +261,7 @@ class SmartyLint_CommentParser_FileCommentParser {
         }
 
         // Only process this tag if there was something to process.
-        if ($wordWasEmpty === false) {
+        if (! $wordWasEmpty) {
             if ($prevTagPos === false) {
                 // There must only be a comment in this doc comment.
                 $this->parseTag('comment', 0, count($this->words));
@@ -270,7 +275,7 @@ class SmartyLint_CommentParser_FileCommentParser {
                     // These are single-word tags, so anything after a newline
                     // is really a comment.
                     for ($endPos = $prevTagPos; $endPos < $numWords; $endPos++) {
-                        if (strpos($this->words[$endPos], $this->smartyl->eolChar) !== false) {
+                        if (str_contains($this->words[$endPos], $this->smartyl->eolChar)) {
                             break;
                         }
                     }
@@ -474,9 +479,9 @@ class SmartyLint_CommentParser_FileCommentParser {
 
         $allowedTags     = (self::$_tags + $this->getAllowedTags());
         $allowedTagNames = array_keys($allowedTags);
-        if ($tag === 'comment' || in_array($tag, $allowedTagNames) === true) {
+        if ($tag === 'comment' || in_array($tag, $allowedTagNames)) {
             $method = 'parse'.$tag;
-            if (method_exists($this, $method) === false) {
+            if (! method_exists($this, $method)) {
                 $error = 'Method '.$method.' must be implemented to process '.$tag.' tags';
                 throw new Exception($error);
             }
@@ -493,9 +498,7 @@ class SmartyLint_CommentParser_FileCommentParser {
 
         $this->orders[] = $tag;
 
-        if ($this->previousElement === null
-            || ($this->previousElement instanceof SmartyLint_CommentParser_DocElement) === false
-        ) {
+        if (! ($this->previousElement instanceof SmartyLint_CommentParser_DocElement)) {
             throw new Exception('Parse method must return a DocElement');
         }
 

--- a/SmartyLint/CommentParser/ParameterElement.php
+++ b/SmartyLint/CommentParser/ParameterElement.php
@@ -76,7 +76,7 @@ class SmartyLint_CommentParser_ParameterElement extends SmartyLint_CommentParser
 
         // Handle special variable type: array(x => y).
         $type = strtolower($this->_type);
-        if ($this->_varName === '=>' && strpos($type, 'array(') !== false) {
+        if ($this->_varName === '=>' && str_contains($type, 'array(')) {
             $rawContent = $this->getRawContent();
             $matches    = array();
             $pattern    = '/^(\s+)(array\(.*\))(\s+)(\$\S*)(\s+)(.*)/i';
@@ -195,7 +195,7 @@ class SmartyLint_CommentParser_ParameterElement extends SmartyLint_CommentParser
      * @return int
      */
     public function getPosition() {
-        if (($this->getPreviousElement() instanceof SmartyLint_CommentParser_ParameterElement) === false) {
+        if (! ($this->getPreviousElement() instanceof SmartyLint_CommentParser_ParameterElement)) {
             return 1;
         } else {
             return ($this->getPreviousElement()->getPosition() + 1);
@@ -262,10 +262,10 @@ class SmartyLint_CommentParser_ParameterElement extends SmartyLint_CommentParser
      * @return boolean
      */
     public function alignsWith(SmartyLint_CommentParser_ParameterElement $other) {
-        if ($this->alignsVariableWith($other) === false) {
+        if (! $this->alignsVariableWith($other)) {
             return false;
         }
-        if ($this->alignsCommentWith($other) === false) {
+        if (! $this->alignsCommentWith($other)) {
             return false;
         }
         return true;

--- a/SmartyLint/File.php
+++ b/SmartyLint/File.php
@@ -184,11 +184,11 @@ class SmartyLint_File {
      */
     public function addTokenListener(SmartyLint_Rule $listener, array $tokens) {
         foreach ($tokens as $token) {
-            if (isset($this->_listeners[$token]) === false) {
+            if (! isset($this->_listeners[$token])) {
                 $this->_listeners[$token] = array();
             }
 
-            if (in_array($listener, $this->_listeners[$token], true) === false) {
+            if (! in_array($listener, $this->_listeners[$token], true)) {
                 $this->_listeners[$token][] = $listener;
             }
         }
@@ -209,11 +209,11 @@ class SmartyLint_File {
         array $tokens
     ) {
         foreach ($tokens as $token) {
-            if (isset($this->_listeners[$token]) === false) {
+            if (! isset($this->_listeners[$token])) {
                 continue;
             }
 
-            if (in_array($listener, $this->_listeners[$token]) === true) {
+            if (in_array($listener, $this->_listeners[$token])) {
                 foreach ($this->_listeners[$token] as $pos => $value) {
                     if ($value === $listener) {
                         unset($this->_listeners[$token][$pos]);
@@ -248,7 +248,7 @@ class SmartyLint_File {
         foreach ($this->_tokens as $stackPtr => $token) {
             // Check for ignored lines.
             if ($token['type'] === 'COMMENT' || $token['type'] === 'DOC_COMMENT') {
-                if (strpos($token['content'], '@noSmartyLint') !== false) {
+                if (str_contains($token['content'], '@noSmartyLint')) {
                     // Ignoring the whole file, just a little late.
                     $this->_errors = array();
                     $this->_warnings = array();
@@ -260,7 +260,7 @@ class SmartyLint_File {
 
             $tokenType = $token['type'];
 
-            if (isset($this->_listeners[$tokenType]) === false) {
+            if (! isset($this->_listeners[$tokenType])) {
                 continue;
             }
 
@@ -270,7 +270,7 @@ class SmartyLint_File {
 
                 // If the file path matches one of our ignore patterns, skip it.
                 $parts = explode('_', $class);
-                if (isset($parts[2]) === true) {
+                if (isset($parts[2])) {
                     $source = $parts[1].'.'.substr($parts[2], 0, -4);
                     $patterns = $this->smartyl->getIgnorePatterns($source);
                     foreach ($patterns as $pattern) {
@@ -350,7 +350,7 @@ class SmartyLint_File {
         $contents = str_replace($this->eolChar, '', $contents);
         $contents = str_replace("\n", '\n', $contents);
         $contents = str_replace("\r", '\r', $contents);
-        if (strpos($contents, '\\') !== false) {
+        if (str_contains($contents, '\\')) {
             $error = 'File has mixed line endings; this may cause incorrect results';
             $this->addError($error, 0, 'Internal.LineEndings.Mixed');
         }
@@ -370,7 +370,7 @@ class SmartyLint_File {
         if ($contents === null) {
             // Determine the newline character being used in this file.
             // Will be either \r, \r\n or \n.
-            if (is_readable($file) === false) {
+            if (! is_readable($file)) {
                 $error = 'Error opening file; file no longer exists or you do not have access to read the file';
                 throw new SmartyLint_Exception($error);
             } else {
@@ -420,14 +420,14 @@ class SmartyLint_File {
      */
     public function addError($error, $stackPtr, $code='', $data=array()) {
         // Work out which rule generated the error.
-        if (substr($code, 0, 9) === 'Internal.') {
+        if (str_starts_with($code, 'Internal.')) {
             // Any internal message.
             $rule = $code;
         } else {
             $parts = explode('_', $this->_activeListener);
 
 
-            if (isset($parts[2]) === true) {
+            if (isset($parts[2])) {
                 $rule = $parts[1].'.'.$parts[2];
 
                 // Remove "Rule" from the end.
@@ -462,11 +462,11 @@ class SmartyLint_File {
         }
 
         $this->_errorCount++;
-        if ($this->_recordErrors === false) {
+        if (! $this->_recordErrors) {
             return;
         }
 
-        if (empty($data) === true) {
+        if (empty($data)) {
             $message = $error;
         } else {
             $message = vsprintf($error, $data);
@@ -486,11 +486,11 @@ class SmartyLint_File {
             //$column  = $this->_tokens[$stackPtr]['column'];
         }
 
-        if (isset($this->_errors[$lineNum]) === false) {
+        if (! isset($this->_errors[$lineNum])) {
             $this->_errors[$lineNum] = array();
         }
 
-        if (isset($this->_errors[$lineNum][$column]) === false) {
+        if (! isset($this->_errors[$lineNum][$column])) {
             $this->_errors[$lineNum][$column] = array();
         }
 
@@ -513,12 +513,12 @@ class SmartyLint_File {
      */
     public function addWarning($warning, $stackPtr, $code='', $data=array()) {
         // Work out which rule generated the warning.
-        if (substr($code, 0, 9) === 'Internal.') {
+        if (str_starts_with($code, 'Internal.')) {
             // Any internal message.
             $rule = $code;
         } else {
             $parts = explode('_', $this->_activeListener);
-            if (isset($parts[2]) === true) {
+            if (isset($parts[2])) {
                 $rule = $parts[1].'.'.$parts[2];
 
                 // Remove "Rule" from the end.
@@ -554,11 +554,11 @@ class SmartyLint_File {
         }
 
         $this->_warningCount++;
-        if ($this->_recordErrors === false) {
+        if (! $this->_recordErrors) {
             return;
         }
 
-        if (empty($data) === true) {
+        if (empty($data)) {
             $message = $warning;
         } else {
             $message = vsprintf($warning, $data);
@@ -578,11 +578,11 @@ class SmartyLint_File {
             //$column  = $this->_tokens[$stackPtr]['column'];
         }
 
-        if (isset($this->_warnings[$lineNum]) === false) {
+        if (! isset($this->_warnings[$lineNum])) {
             $this->_warnings[$lineNum] = array();
         }
 
-        if (isset($this->_warnings[$lineNum][$column]) === false) {
+        if (! isset($this->_warnings[$lineNum][$column])) {
             $this->_warnings[$lineNum][$column] = array();
         }
 
@@ -652,7 +652,7 @@ class SmartyLint_File {
     public static function tokenizeString(
         $string,
         $tokenizer,
-        $eolChar='\n',
+        $eolChar,
         $leftD,
         $rightD,
         $autoLiteral
@@ -705,7 +705,7 @@ class SmartyLint_File {
                 }
             }
 
-            if ($found === true) {
+            if ($found) {
                 if ($value === null) {
                     return $i;
                 } else if ($this->_tokens[$i]['content'] === $value) {

--- a/SmartyLint/Reporting.php
+++ b/SmartyLint/Reporting.php
@@ -42,7 +42,7 @@ class SmartyLint_Reporting {
         $width = 70;
 
         foreach ($report['files'] as $filename => $file) {
-            if (empty($file['messages']) === true) {
+            if (empty($file['messages'])) {
                 continue;
             }
 
@@ -188,11 +188,11 @@ class SmartyLint_Reporting {
                             );
                     }
 
-                    if (isset($errors[$line]) === false) {
+                    if (! isset($errors[$line])) {
                         $errors[$line] = array();
                     }
 
-                    if (isset($errors[$line][$column]) === true) {
+                    if (isset($errors[$line][$column])) {
                         $errors[$line][$column] = array_merge(
                             $newWarnings,
                             $errors[$line][$column]

--- a/SmartyLint/Rule.php
+++ b/SmartyLint/Rule.php
@@ -45,7 +45,7 @@ interface SmartyLint_Rule {
      *    print_r($tokens[$stackPtr]);
      * </code>
      *
-     * If the rule discovers an anomilty in the code, they can raise an error
+     * If the rule discovers an anomaly in the code, they can raise an error
      * by calling addError() on the SmartyLint_File object, specifying an error
      * message and the position of the offending token:
      *

--- a/SmartyLint/Rules/Commenting/FileCommentRule.php
+++ b/SmartyLint/Rules/Commenting/FileCommentRule.php
@@ -94,7 +94,7 @@ class Rules_Commenting_FileCommentRule implements SmartyLint_Rule {
         }
 
         $comment = $this->commentParser->getComment();
-        if (is_null($comment) === true) {
+        if (is_null($comment)) {
             $error = 'File doc comment is empty';
             $smartylFile->addError($error, $stackPtr, 'Empty');
             return;
@@ -115,7 +115,7 @@ class Rules_Commenting_FileCommentRule implements SmartyLint_Rule {
 
         // Exactly one blank line between short and long description.
         $long = $comment->getLongComment();
-        if (empty($long) === false) {
+        if (! empty($long)) {
             $between = $comment->getWhiteSpaceBetween();
             $newlineBetween = substr_count($between, $smartylFile->eolChar);
             if ($newlineBetween !== 2) {
@@ -179,7 +179,7 @@ class Rules_Commenting_FileCommentRule implements SmartyLint_Rule {
     protected function processParams($commentStart) {
         $params = $this->commentParser->getParams();
 
-        if (empty($params) === false) {
+        if (! empty($params)) {
 
             $lastParm = (count($params) - 1);
             if (substr_count($params[$lastParm]->getWhitespaceAfter(), $this->currentFile->eolChar) !== 2) {
@@ -235,7 +235,7 @@ class Rules_Commenting_FileCommentRule implements SmartyLint_Rule {
                     $previousName = ($previousParam->getVarName() !== '') ? $previousParam->getVarName() : 'UNKNOWN';
 
                     // Check to see if the parameters align properly.
-                    if ($param->alignsVariableWith($previousParam) === false) {
+                    if (! $param->alignsVariableWith($previousParam)) {
                         $error = 'The variable names for parameters %s (%s) and %s (%s) do not align';
                         $data  = array(
                                   $previousName,
@@ -246,7 +246,7 @@ class Rules_Commenting_FileCommentRule implements SmartyLint_Rule {
                         $this->currentFile->addError($error, array(0, $errorPos), 'ParameterNamesNotAligned', $data);
                     }
 
-                    if ($param->alignsCommentWith($previousParam) === false) {
+                    if (! $param->alignsCommentWith($previousParam)) {
                         $error = 'The comments for parameters %s (%s) and %s (%s) do not align';
                         $data  = array(
                                   $previousName,

--- a/SmartyLint/Rules/Commenting/FixmeRule.php
+++ b/SmartyLint/Rules/Commenting/FixmeRule.php
@@ -35,7 +35,7 @@ class Rules_Commenting_FixmeRule implements SmartyLint_Rule {
 
         $content = $tokens[$stackPtr]['content'];
 
-        if (isset($tokens[$stackPtr]['multi']) && $tokens[$stackPtr]['multi'] == true) {
+        if ($tokens[$stackPtr]['multi'] ?? false) {
             $content = explode($smartylFile->eolChar, $content);
         } else {
             $content = array($content);

--- a/SmartyLint/Rules/Commenting/TodoRule.php
+++ b/SmartyLint/Rules/Commenting/TodoRule.php
@@ -35,7 +35,7 @@ class Rules_Commenting_TodoRule implements SmartyLint_Rule {
 
         $content = $tokens[$stackPtr]['content'];
 
-        if (isset($tokens[$stackPtr]['multi']) && $tokens[$stackPtr]['multi'] == true) {
+        if ($tokens[$stackPtr]['multi'] ?? false) {
             $content = explode($smartylFile->eolChar, $content);
         } else {
             $content = array($content);
@@ -55,11 +55,7 @@ class Rules_Commenting_TodoRule implements SmartyLint_Rule {
                     $error .= ' "%s"';
                 }
 
-                if (isset($tokens[$stackPtr]['start'])) {
-                    $l = $tokens[$stackPtr]['start'];
-                } else {
-                    $l = $tokens[$stackPtr]['line'];
-                }
+                $l = $tokens[$stackPtr]['start'] ?? $tokens[$stackPtr]['line'];
                 $smartylFile->addWarning($error, array($l, $cLine), $type, $data);
             }
             $cLine++;

--- a/SmartyLint/Rules/Indent/DisallowTabIndentRule.php
+++ b/SmartyLint/Rules/Indent/DisallowTabIndentRule.php
@@ -33,7 +33,7 @@ class Rules_Indent_DisallowTabIndentRule implements SmartyLint_Rule {
     public function process(SmartyLint_File $smartylFile, $stackPtr) {
         $tokens = $smartylFile->getTokens();
 
-        if (strpos($tokens[$stackPtr]['content'], "\t") !== false) {
+        if (str_contains($tokens[$stackPtr]['content'], "\t")) {
             $error = 'Spaces must be used to indent lines; tabs are not allowed';
             $smartylFile->addError($error, $stackPtr, 'TabsUsed');
         }

--- a/SmartyLint/Rules/Whitespace/TagsWhitespaceRule.php
+++ b/SmartyLint/Rules/Whitespace/TagsWhitespaceRule.php
@@ -36,7 +36,7 @@ class Rules_Whitespace_TagsWhitespaceRule implements SmartyLint_Rule {
         $data = $tokens[$stackPtr];
         $content = $data['content'];
 
-        if (isset($data['multi']) && $data['multi'] === true) {
+        if (isset($data['multi']) && $data['multi']) {
             // Don't check anything for multiline smarty content as smarty
             // itself ignores it assuming it is CSS or JavaScript block.
         } else {

--- a/demo/other_errors.tpl
+++ b/demo/other_errors.tpl
@@ -18,6 +18,6 @@ School : {$school} <br>
 
 {* TODO:: We don't allow TODO comments. *}
 
-We dont allowe HTML comments.
+We don't allow HTML comments.
 <!-- This is HTML comment -->
-
+<!-- This is an unclosed HTML comment


### PR DESCRIPTION
Related to #3 

- Handle edge cases in HTML comment token

- Ensure PHP 8.1 compatibility

- Leverage modern PHP 8  syntax

- Remove redundant comparisons and improve readability