### PR TITLE
[UPD] Update the package name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "umakantp/smarty-lint",
+    "name": "smarty/smarty-lint",
     "description": "SmartyLint is a PHP tool that helps you find issues in your Smarty template files. It's designed to assist you in writing cleaner and more consistent Smarty templates",
     "type": "library",
     "homepage": "https://github.com/umakantp/SmartyLint",


### PR DESCRIPTION
Update composer.json to set the package name to "smarty/smarty-lint".

We agreed to publish this package under the Smarty namespace. Packagist takes the name from composer.json and it can’t be changed later, so this update is needed before submitting.